### PR TITLE
Add a 'manualFix' custom event

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -41,6 +41,17 @@ We also report a running total since the extension was installed via `customMeas
 {"total":1}
 ```
 
+## manualFix
+
+This is somewhat more complicated scenario:
+
+1. The user typed some text.
+1. The extension recommended a change (either via `negativeWord` or `negativeSentence`).
+1. The user changed the text.
+1. Now the extension finds no issues.
+
+`appliedSuggestion` should not trigger `manualFix`, file a bug if it does!
+
 ## ignoreSuggestion
 
 The user clicked `Ignore in this text`:

--- a/src/background/extension-main.js
+++ b/src/background/extension-main.js
@@ -246,6 +246,8 @@ class BackgroundApp {
         return (
             isPageLoadedMessage(e)
                 ? (s = this._onPageLoadedMessage(t, e))
+                : isAppliedSuggestion(e)
+                ? (s = this._onAppliedSuggestionMessage(t, e))
                 : isLTAssistantStatusChangedMessage(e)
                 ? (s = this._onLTAssistantStatusChangedMessage(t, e))
                 : isCheckForPaidSubscriptionMessage(e)
@@ -314,6 +316,9 @@ class BackgroundApp {
                     console.error("Error detecting language", e);
                 }),
             this._updateBadge(a, s);
+    }
+    static _onAppliedSuggestionMessage(e, t) {;
+        window.appliedSuggestion(t.appliedSuggestions);
     }
     static _onLTAssistantStatusChangedMessage(e, t) {
         const a = t.tabId || e.tab.id;

--- a/src/background/validator.js
+++ b/src/background/validator.js
@@ -106,7 +106,7 @@ class Validator {
             // TODO: This is terrible, but the request is already JSON at this point
             // If we parse the JSON, and look at the 'text' property. This is the data.
             var text = JSON.parse(t.body.get('data')).text;
-            await window.getMatches(text, matches, true);
+            await window.getMatches(text, matches);
         }
 
         var response = {

--- a/src/common/messages.js
+++ b/src/common/messages.js
@@ -2,6 +2,9 @@
 function isPageLoadedMessage(n) {
     return "PAGE_LOADED" === n.command;
 }
+function isAppliedSuggestion(n) {
+    return "APPLIED_SUGGESTION" === n.command;
+}
 function isLTAssistantStatusChangedMessage(n) {
     return "LTASSISTANT_STATUS_CHANGED" === n.command;
 }

--- a/src/content/ltAssistant.js
+++ b/src/content/ltAssistant.js
@@ -1451,7 +1451,7 @@ class LTAssistant {
         const { appliedSuggestions: n } = this._storageController.getStatistics();
         let appliedSuggestions = n + 1;
         this._storageController.updateStatistics({ appliedSuggestions: appliedSuggestions });
-        window.aiTrackEvent('appliedSuggestion', { total: appliedSuggestions });
+        browser.runtime.sendMessage({ command: "APPLIED_SUGGESTION", appliedSuggestions: appliedSuggestions });
     }
 }
 (LTAssistant.events = { UPDATE: "_lt-state-updated", DESTROY: "_lt-destroy" }),

--- a/test/validator.js
+++ b/test/validator.js
@@ -25,4 +25,29 @@ describe('validator', () => {
         expect(matches.length).to.be.equal(2);
     });
 
+    it('shouldReportManualFix', async () => {
+        // Reset initial state
+        client.clearState();
+        // No suggestions
+        expect(client.shouldReportManualFix([])).to.be.equal(false);
+        // One suggestion
+        expect(client.shouldReportManualFix([ "one" ])).to.be.equal(false);
+        // No suggestions
+        expect(client.shouldReportManualFix([])).to.be.equal(true);
+        // No suggestions, again
+        expect(client.shouldReportManualFix([])).to.be.equal(false);
+    });
+
+    it('shouldReportManualFix after suggestion', async () => {
+        // Reset initial state
+        client.clearState();
+        // One suggestion
+        expect(client.shouldReportManualFix([ "one" ])).to.be.equal(false);
+        // Applied suggestion
+        client.appliedSuggestion(42);
+        // No suggestions
+        expect(client.shouldReportManualFix([])).to.be.equal(false);
+        // No suggestions, again
+        expect(client.shouldReportManualFix([])).to.be.equal(false);
+    });
 });


### PR DESCRIPTION
Implements https://github.com/jonathanpeppers/inclusive-code-comments/issues/24

I implemented the bulk of the logic for this in
`src-packed/validator.js`. A `hasFoundSuggestionsBefore` variable
tracks the state -- and we report `manualFix` when a fix is resolved
after a previous one was found. Doing it this way, I was able to write
tests and test the interaction between the `appliedSuggestion` event.

The only problem I found was the way `ltAssistant.js` sent the
`appliedSuggestion` event from *inside* web pages, instead of from the
extension in the background. So we ended up with two instances of
`src-packed/validator.js` and we get two events: `appliedSuggestion`
then `manualFix`!

To solve this, I use `sendMessage()` to send from the page:

    browser.runtime.sendMessage({ command: "APPLIED_SUGGESTION", appliedSuggestions: appliedSuggestions });

Then in the background `extension-main.js` has a
`_onAppliedSuggestionMessage()` method to receive the message.

So the background extension sends both messages and can properly
handle the state now.

Other changes:

* `appinsights` can now be loaded in tests since 9ee7a949, so I used a
  `loadAppInsights()` method. We don't need null checks anymore for it.