### PR TITLE
Hide extra settings that we can use in the future

### DIFF
--- a/src/options/options.html
+++ b/src/options/options.html
@@ -24,9 +24,9 @@
 			data-t="generalSettingsHeadline"></div>
 
 		<div class="lt-options__personalDictionary-toggle lt-options-toggle" id="personalDictionary"
-			data-t="settingsDictionaryHeadline"></div>
+			data-t="settingsDictionaryHeadline" style="display: none;"></div>
 
-		<div id="personalDictionary-options" class="lt-options__personalDictionary lt-toggle-box">
+		<div id="personalDictionary-options" class="lt-options__personalDictionary lt-toggle-box" style="display: none;">
 			<div class="lt-add-input-wrapper">
 				<input id="personalDictionaryInput" type="text" name="fname"
 					data-t-placeholder="settingsAddOrFilterWords" autocomplete="off">
@@ -51,10 +51,10 @@
 			</div>
 		</div>
 
-		<div class="lt-options__ignoredRules-toggle lt-options-toggle" id="ignoredRules" data-t="ignoredRulesDesc">
+		<div class="lt-options__ignoredRules-toggle lt-options-toggle" id="ignoredRules" data-t="ignoredRulesDesc" style="display: none;">
 		</div>
 
-		<div id="ignoredRules-options" class="lt-options__ignoredRules lt-toggle-box">
+		<div id="ignoredRules-options" class="lt-options__ignoredRules lt-toggle-box" style="display: none;">
 			<div id="ignoredRules-options__emptyState" class="lt-emptyState" data-t="settingsEmptyIgnoredRules"></div>
 			<div id="ignoredRules-optionsInside">
 				<ul id="ignoredRulesList" class="lt-options__rules"></ul>


### PR DESCRIPTION
Hide rules and personal dictionary, I m not removing these as we see that they could help us in the future.

- personal dictionary for words we want flagged
- rules related with how we analyse the text 

Fixes #21 