### PR TITLE
Remove case sensitivity - match casing of suggestions

### DIFF
--- a/src-packed/suggestions.js
+++ b/src-packed/suggestions.js
@@ -71,9 +71,17 @@ export function getSuggestions(text) {
     for (const [key, values] of Object.entries(allReplacements)) {
         var regex = new RegExp('\\b' + key + '\\b', "gi");
         var index = text.search(regex);
-        var replacements = [];
-        values.forEach(value => replacements.push({ value: value }));
+
         if (index != -1) {
+            var replacements = [];
+            var textToReplace = text.substring(index, index + key.length);
+            
+            if (isCapitalized(textToReplace)) {
+                values.forEach(value => replacements.push({ value: capitalize(value) }));
+            } else {
+                values.forEach(value => replacements.push({ value: value }));
+            }
+
             suggestions.push({
                 index: index,
                 length: key.length,
@@ -82,4 +90,12 @@ export function getSuggestions(text) {
         }
     }
     return suggestions;
+}
+
+export function capitalize(word) {
+    return word.charAt(0).toUpperCase() + word.slice(1);
+}
+
+export function isCapitalized(word) {
+    return /[A-Z]/.test(word.charAt(0));
 }

--- a/src-packed/suggestions.js
+++ b/src-packed/suggestions.js
@@ -72,10 +72,7 @@ export function getSuggestions(text) {
         var regex = new RegExp('\\b' + key + '\\b', "gi");
         var index = text.search(regex);
         var replacements = [];
-        values.forEach(value => {
-            replacements.push({ value: key });
-            replacements.push({ value: value });
-        });
+        values.forEach(value => replacements.push({ value: value }));
         if (index != -1) {
             suggestions.push({
                 index: index,

--- a/test/suggestions.js
+++ b/test/suggestions.js
@@ -11,7 +11,7 @@ describe('suggestions', () => {
         expect(result[0]).to.eql({
             index: 0,
             length: 6,
-            replacements: [ { value: "master" }, { value: "main" }, { value: "master" }, { value: "primary" } ],
+            replacements: [ { value: "main" }, { value: "primary" } ],
         });
     });
 
@@ -20,7 +20,7 @@ describe('suggestions', () => {
         expect(result[0]).to.eql({
             index: 14,
             length: 6,
-            replacements: [ { value: "master" }, { value: "main" }, { value: "master" }, { value: "primary" } ],
+            replacements: [ { value: "main" }, { value: "primary" } ],
         });
     });
 
@@ -29,7 +29,7 @@ describe('suggestions', () => {
         expect(result[0]).to.eql({
             index: 17,
             length: 6,
-            replacements: [ { value: "master" }, { value: "main" }, { value: "master" }, { value: "primary" } ],
+            replacements: [ { value: "main" }, { value: "primary" } ],
         });
     });
 
@@ -38,7 +38,7 @@ describe('suggestions', () => {
         expect(result[0]).to.eql({
             index: 7,
             length: 11,
-            replacements: [ { value: "crushing it" }, { value: "elevating" }, { value: "crushing it" }, { value: "exceeding expectations" }, { value: "crushing it" }, { value: "excelling" } ],
+            replacements: [ { value: "elevating" }, { value: "exceeding expectations" }, { value: "excelling" } ],
         });
     });
 

--- a/test/suggestions.js
+++ b/test/suggestions.js
@@ -7,7 +7,7 @@ describe('suggestions', () => {
     });
 
     it('Match at beginning', async () => {
-        var result = client.getSuggestions("Master this");
+        var result = client.getSuggestions("master this");
         expect(result[0]).to.eql({
             index: 0,
             length: 6,
@@ -30,6 +30,15 @@ describe('suggestions', () => {
             index: 17,
             length: 6,
             replacements: [ { value: "main" }, { value: "primary" } ],
+        });
+    });
+
+    it('Retrieve capitalized suggestions for capitalized word', async () => {
+        var result = client.getSuggestions("Ship this to the Master branch!");
+        expect(result[0]).to.eql({
+            index: 17,
+            length: 6,
+            replacements: [ { value: "Main" }, { value: "Primary" } ],
         });
     });
 


### PR DESCRIPTION
If the text to replace is capitalized, the suggestions should also be capitalized!
Also, the suggestions should not be duplicated and should be the same regardless of casing.

Fixes #31 

Screenshot example:
<img width="334" alt="Screenshot 2021-11-24 at 12 03 05 PM" src="https://user-images.githubusercontent.com/21988533/143282946-c8250eaa-012d-4e91-9dad-e7ed4e7280a9.png">



