### PR TITLE
Fix "comment too brief" off by one error

### DIFF
--- a/src-packed/validator.js
+++ b/src-packed/validator.js
@@ -25,7 +25,7 @@ export async function getMatches(text, matches) {
             "message": "This is comment is too brief. Could you elaborate?",
             "shortMessage": "Comment is brief",
             "offset": 0,
-            "length": text.length-1,
+            "length": text.length,
             "rule": { "id": "NON_STANDARD_WORD", "subId": "1", "description": "Negative word", "issueType": "misspelling", "category": { "id": "TYPOS", "name": "Small text" } },
             "replacements": [],
             "type": { "typeName": "Other" },

--- a/test/validator.js
+++ b/test/validator.js
@@ -60,14 +60,16 @@ describe('validator', () => {
     });
 
     it('Brief text suggestion', async () => {
+        var text = "Great changes";
         var matches = [];
-        var result = client.getMatches("Great changes", matches);
+        client.getMatches(text, matches);
         expect(matches.length).to.be.equal(1);
+        expect(matches[0].length).to.be.equal(text.length);
     });
     
     it('Brief text no suggestion', async () => {
         var matches = [];
-        var result = client.getMatches("These changes are more than 15 characters", matches);
+        client.getMatches("These changes are more than 15 characters", matches);
         expect(matches.length).to.be.equal(0);
     });
 });


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/inclusive-code-comments/issues/48

This was doing `length: text.length - 1`, which didn't seem to be right.

Removing the `-1` fixed the issue, and I updated a test for this.

![image](https://user-images.githubusercontent.com/840039/145600788-a090ed32-50fe-413f-b8f2-687033708a72.png)

![image](https://user-images.githubusercontent.com/840039/145600802-e1604e70-82c9-4ba8-a7fd-696ed3c4c3d4.png)
