### PR TITLE
Skip code blocks when analyzing text. Fixes #52.

### DIFF
--- a/src-packed/textAnalytics.js
+++ b/src-packed/textAnalytics.js
@@ -9,7 +9,61 @@ function defaultApiKey() {
     return "EMPTY_API_KEY";
 }
 
+// Replace fenced / indented code blocks with spaces to not analyze them
+export function preprocessText (text) {
+    var atStartOfLine = true;
+    var inFencedCodeBlock = false;
+    var inIndentedCodeBlock = false;
+    var result = "";
+    for (var i = 0; i < text.length; i++) {
+        var c = text.charAt(i);
+        if (c == '\n') {
+            atStartOfLine = true;
+            inIndentedCodeBlock = false;
+            result += c;
+            continue;
+        }
+
+        if (!atStartOfLine) {
+            if (inIndentedCodeBlock || inFencedCodeBlock) {
+                result += " ";
+            } else {
+                result += c;
+            }
+            continue;
+        }
+
+        if (atStartOfLine && c == '`' && text.substring (i, i + 3) == "```") {
+            inFencedCodeBlock = !inFencedCodeBlock;
+            result += "   ";
+            i += 2;
+            atStartOfLine = false;
+            continue;
+        }
+
+        if (inFencedCodeBlock) {
+            result += " ";
+            atStartOfLine = false;
+            continue;
+        }
+
+        if (atStartOfLine && c == ' ' && text.substring (i, i + 4) == "    ") {
+            inIndentedCodeBlock = true;
+            result += "    ";
+            i += 3;
+            atStartOfLine = false;
+            continue;
+        }
+
+        result += c;
+        atStartOfLine = false;
+    }
+
+    return result;
+}
+
 export async function analyzeSentiment(text) {
+    text = preprocessText(text);
     const [result] = await client.analyzeSentiment([text]);
     return result;
 }

--- a/test/textAnalytics.js
+++ b/test/textAnalytics.js
@@ -17,4 +17,34 @@ describe('textAnalytics', () => {
         const result = await client.analyzeSentiment("This is great!");
         expect(result.sentences[0].sentiment).to.be.equal("positive");
     });
+
+    it('Fenced code blocks negative', async () => {
+        const result = await client.analyzeSentiment("```\nThis is terrible!\n```\nHello, World!\n");
+        expect(result.sentences[0].sentiment).to.be.equal("neutral");
+    });
+
+    it('Indented code blocks negative', async () => {
+        const result = await client.analyzeSentiment("    This is terrible!\nHello, World!\n");
+        expect(result.sentences[0].sentiment).to.be.equal("neutral");
+    });
+
+    it('Preprocess 1', () => {
+        const result = client.preprocessText ("abc");
+        expect(result).to.be.equal("abc");
+    });
+
+    it('Preprocess Indented 1', () => {
+        const result = client.preprocessText ("    abc");
+        expect(result).to.be.equal("       ");
+    });
+
+    it('Preprocess Indented 2', () => {
+        const result = client.preprocessText ("    abc\ndef\n    ghi");
+        expect(result).to.be.equal("       \ndef\n       ");
+    });
+
+    it('Preprocess Fenced 1', () => {
+        const result = client.preprocessText ("```abc\ndef\n```ghi");
+        expect(result).to.be.equal("      \n   \n   ghi");
+    });
 });

--- a/test/textAnalytics.js
+++ b/test/textAnalytics.js
@@ -23,9 +23,27 @@ describe('textAnalytics', () => {
         expect(result.sentences[0].sentiment).to.be.equal("neutral");
     });
 
+    it('Fenced code blocks negative, offset', async () => {
+        const text = "```\nHello, World!\n```\nThis is terrible!\n";
+        const result = await client.analyzeSentiment(text);
+        var sentence = result.sentences[0];
+        expect(sentence.sentiment).to.be.equal("negative");
+        expect(sentence.offset).to.be.equal(0);
+        expect(sentence.length).to.be.equal(text.length - 1); // -1 is the \n
+    });
+
     it('Indented code blocks negative', async () => {
         const result = await client.analyzeSentiment("    This is terrible!\nHello, World!\n");
         expect(result.sentences[0].sentiment).to.be.equal("neutral");
+    });
+
+    it('Indented code blocks negative, offset', async () => {
+        const text = "This is terrible!\n    Hello, World!";
+        const result = await client.analyzeSentiment(text);
+        var sentence = result.sentences[0];
+        expect(sentence.sentiment).to.be.equal("negative");
+        expect(sentence.offset).to.be.equal(0);
+        expect(sentence.length).to.be.equal("This is terrible!".length);
     });
 
     it('Preprocess 1', () => {


### PR DESCRIPTION
Skip code blocks (both fenced and indented) when analyzing text.

This is done by replacing code blocks with spaces before sending text off to
be analyzed (this way analyzed text has the same location information as the
input).

Fixes https://github.com/jonathanpeppers/inclusive-code-comments/issues/52.