### PR TITLE
Add custom negative sentiments to suggestions.js

### DIFF
--- a/src-packed/suggestions.js
+++ b/src-packed/suggestions.js
@@ -63,6 +63,8 @@ const allReplacements = {
     // ageist
     "grandfather": ["flagship", "established", "rollover", "carryover", "classic"],
     "legacy": ["flagship", "established", "rollover", "carryover", "classic"],
+    // custom negative sentiment just leave replacements empty
+    "is pants": [],
 };
 
 // returns suggestions for certain words


### PR DESCRIPTION
Context #46

The Text Analysis service does not seem to pick up some regional
phrases which are negative. To work around this for now lets start adding
additional negative sentiments to the suggestions.js.

We do not need to provide replacement suggestions, we can leave them empty
and the extension will flag them as negative as usual.