### PR TITLE
[telemetry] better logic for the 'manualFix' event

### DIFF
--- a/test/validator.js
+++ b/test/validator.js
@@ -59,6 +59,21 @@ describe('validator', () => {
         expect(client.shouldReportManualFix([])).to.be.equal(false);
     });
 
+    it('shouldReportManualFix multiple issues', async () => {
+        // Reset initial state
+        client.clearState();
+        // No suggestions
+        expect(client.shouldReportManualFix([])).to.be.equal(false);
+        // Two suggestions
+        expect(client.shouldReportManualFix([ "one", "two" ])).to.be.equal(false);
+        // One suggestion
+        expect(client.shouldReportManualFix([ "one" ])).to.be.equal(true);
+        // No suggestions
+        expect(client.shouldReportManualFix([])).to.be.equal(true);
+        // No suggestions, again
+        expect(client.shouldReportManualFix([])).to.be.equal(false);
+    });
+
     it('Brief text suggestion', async () => {
         var text = "Great changes";
         var matches = [];


### PR DESCRIPTION
After looking at #57, the number of `manualFix` events seemed low.

It looked like we only reported this event when there was an error in
the past, and now all errors are fixed. Change this value to an
integer of the number of errors, and we can report `manualFix` if the
number of errors *goes down*.

This way we'll get the `manualFix` event if you have more than one
error and fix at least one.