### PR TITLE
Skip image tags when analyzing text.

### DIFF
--- a/src-packed/textAnalytics.js
+++ b/src-packed/textAnalytics.js
@@ -19,8 +19,9 @@ function removeImageTags (text) {
         var end = result.indexOf (")", endTag + 2);
         if (end == -1)
             break;
-        var space = " ".repeat (end - startTag + 1);
-        result = result.substring (0, startTag).concat (space, result.substring (end + 1));
+        var alttext = result.substring (startTag + 2, endTag);
+        var space = " ".repeat (end - endTag);
+        result = result.substring (0, startTag).concat (". ", alttext, ".", space, result.substring (end + 1));
         startTag = result.indexOf ("![", end + 1);
     }
     return result;

--- a/src-packed/textAnalytics.js
+++ b/src-packed/textAnalytics.js
@@ -9,8 +9,25 @@ function defaultApiKey() {
     return "EMPTY_API_KEY";
 }
 
+function removeImageTags (text) {
+    var startTag = text.indexOf ("![");
+    var result = text;
+    while (startTag >= 0) {
+        var endTag = result.indexOf ("](", startTag + 2);
+        if (endTag == -1)
+            break;
+        var end = result.indexOf (")", endTag + 2);
+        if (end == -1)
+            break;
+        var space = " ".repeat (end - startTag + 1);
+        result = result.substring (0, startTag).concat (space, result.substring (end + 1));
+        startTag = result.indexOf ("![", end + 1);
+    }
+    return result;
+}
+
 // Replace fenced / indented code blocks with spaces to not analyze them
-export function preprocessText (text) {
+function removeCodeBlocks (text) {
     var atStartOfLine = true;
     var inFencedCodeBlock = false;
     var inIndentedCodeBlock = false;
@@ -59,6 +76,12 @@ export function preprocessText (text) {
         atStartOfLine = false;
     }
 
+    return result;
+}
+
+export function preprocessText (text) {
+    var result = removeCodeBlocks (text);
+    result = removeImageTags (result);
     return result;
 }
 

--- a/test/textAnalytics.js
+++ b/test/textAnalytics.js
@@ -99,25 +99,34 @@ describe('textAnalytics', () => {
 
     it('Image tag 1', () => {
         const text = client.preprocessText ("abc![image](abc)def");
-        expect(text).to.be.equal           ("abc             def");
+        expect(text).to.be.equal           ("abc. image.     def");
     });
 
     it('Image tag 2', () => async () => {
         const text = client.preprocessText ("abc![image](https://bad.com/this/is/terrible)def");
-        expect(text).to.be.equal           ("abc                                          def");
+        expect(text).to.be.equal           ("abc. image.                                  def");
         const result = await client.analyzeSentiment(text);
         expect(result.sentences[0].sentiment).to.be.equal("neutral");
     });
 
     it('Image tag 3', () => async () => {
         const text = client.preprocessText ("abc![alt text](https://bad.com/this/is/terrible)def");
-        expect(text).to.be.equal           ("abc                                             def");
+        expect(text).to.be.equal           ("abc. alt text.                                  def");
         const result = await client.analyzeSentiment(text);
         expect(result.sentences[0].sentiment).to.be.equal("neutral");
     });
 
     it('Image tag 4', () => {
         const text = client.preprocessText ("abc![image1](abc)![image2](def)def");
-        expect(text).to.be.equal           ("abc                            def");
+        expect(text).to.be.equal           ("abc. image1.     . image2.     def");
+    });
+
+    it('Image tag 5', () => async () => {
+        const text = client.preprocessText ("abc![I am good](https://good.com/)  ![You are bad](https://bad.com/)");
+        expect(text).to.be.equal           ("abc. I am good.                       You are bad.                  ");
+        const result = await client.analyzeSentiment(text);
+        expect(result.sentences[0].sentiment).to.be.equal("neutral");
+        expect(result.sentences[1].sentiment).to.be.equal("neutral");
+        expect(result.sentences[2].sentiment).to.be.equal("negative");
     });
 });

--- a/test/textAnalytics.js
+++ b/test/textAnalytics.js
@@ -65,4 +65,27 @@ describe('textAnalytics', () => {
         const result = client.preprocessText ("```abc\ndef\n```ghi");
         expect(result).to.be.equal("      \n   \n   ghi");
     });
+
+    it('Image tag 1', () => {
+        const text = client.preprocessText ("abc![image](abc)def");
+        expect(text).to.be.equal           ("abc             def");
+    });
+
+    it('Image tag 2', () => async () => {
+        const text = client.preprocessText ("abc![image](https://bad.com/this/is/terrible)def");
+        expect(text).to.be.equal           ("abc                                          def");
+        const result = await client.analyzeSentiment(text);
+        expect(result.sentences[0].sentiment).to.be.equal("neutral");
+    });
+
+    it('Image tag 3', () => async () => {
+        const text = client.preprocessText ("abc![alt text](https://bad.com/this/is/terrible)def");
+        expect(text).to.be.equal           ("abc                                             def");
+        const result = await client.analyzeSentiment(text);
+        expect(result.sentences[0].sentiment).to.be.equal("neutral");
+    });
+    it('Image tag 4', () => {
+        const text = client.preprocessText ("abc![image1](abc)![image2](def)def");
+        expect(text).to.be.equal           ("abc                            def");
+    });
 });


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/inclusive-code-comments/issues/62

Skip image tags when analyzing text.

This is done by replacing the image url with spaces before sending text off to be analyzed (this way analyzed text has the same location information as the input).

Only the image url is removed, the alt text is kept. I'm also adding at the beginning and end of image tags, so that previous sentences, the alt text, and the next sentence are all actually considered separate sentences.