### PR TITLE
[ci] Unzip extension before uploading

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,10 +33,14 @@ jobs:
 
       - name: run tests
         run: npx xt-test
-        
+
+      # Upload unzipped artifact content to avoid creating a nested .zip artifact
+      - name: unzip release.zip
+        run: unzip release.zip -d unzipped-release
+
       - name: archive release.zip
         uses: actions/upload-artifact@v2
         with:
-          name: artifacts
-          path: release.zip
+          name: release
+          path: unzipped-release
           if-no-files-found: error


### PR DESCRIPTION
Fixes: #66
Replaces: #72

Attempt to work around the [zipped artifact download limitation][0] by
uploading unzipped content.

[0]: https://github.com/actions/upload-artifact#zipped-artifact-downloads