### PR TITLE
Add ignore list for certain negative phrases

### DIFF
--- a/src-packed/textAnalytics.js
+++ b/src-packed/textAnalytics.js
@@ -68,7 +68,7 @@ export function preprocessIgnorableNegativeText (text) {
     var regex = new RegExp(ignorablePhraseRegex, "gi");
     var replacedResult = text.replace(regex,
         function(stringToReplace) {
-            return " ".repeat(stringToReplace.length);;
+            return " ".repeat(stringToReplace.length);
         }
     )
     return replacedResult;

--- a/src-packed/textAnalytics.js
+++ b/src-packed/textAnalytics.js
@@ -62,8 +62,33 @@ export function preprocessText (text) {
     return result;
 }
 
+// Replace ignorable phrases that produce a negative sentiment with spaces
+export function preprocessIgnorableNegativeText (text) {
+    // Match all case-insensitive instances
+    var regex = new RegExp(ignorablePhraseRegex, "gi");
+    var replacedResult = text.replace(regex,
+        function(stringToReplace) {
+            return " ".repeat(stringToReplace.length);;
+        }
+    )
+    return replacedResult;
+}
+
 export async function analyzeSentiment(text) {
     text = preprocessText(text);
+    text = preprocessIgnorableNegativeText(text);
     const [result] = await client.analyzeSentiment([text]);
     return result;
 }
+
+/*
+    Contains a list of phrases that produce a negative sentiment but can be ignored.
+    Be conscientious when adding new items to this file, as we don't want to filter out generic words/phrases that can be used in many contexts.
+*/
+const ignorablePhraseRegex =
+    "build failure|" +
+    "error|" +
+    "ignore|" +
+    "test failure|" +
+    "warning|" +
+    "";

--- a/test/textAnalytics.js
+++ b/test/textAnalytics.js
@@ -65,4 +65,36 @@ describe('textAnalytics', () => {
         const result = client.preprocessText ("```abc\ndef\n```ghi");
         expect(result).to.be.equal("      \n   \n   ghi");
     });
+
+    it("Preprocess Ignorable sentence", () => {
+        const text     = "These test failures can be ignored.";
+        const expected = "These             s can be       d."
+        const result = client.preprocessIgnorableNegativeText (text);
+        expect(result).to.be.equal(expected);
+    });
+
+    it("Ignorable sentence", async () => {
+        const result = await client.analyzeSentiment("I see a couple of new warnings and errors.");
+        expect(result.sentences[0].sentiment).not.to.be.equal("negative");
+    });
+
+    it("Ignorable negative sentence", async () => {
+        const result = await client.analyzeSentiment("There are some new test failures, this is terrible.");
+        expect(result.sentences[0].sentiment).to.be.equal("negative");
+    });
+
+    it("Ignorable sentence and negative sentence, offset and length", async () => {
+        const sen1 = "I see a new error in the build.";
+        const sen2 = "This is the worst thing that has ever happened."
+        const result = await client.analyzeSentiment(sen1 + " " + sen2);
+        var res1 = result.sentences[0];
+        var res2 = result.sentences[1];
+        expect(res1.sentiment).not.to.be.equal("negative");
+        expect(res2.sentiment).to.be.equal("negative");
+        expect(res1.offset).to.be.equal(0);
+        expect(res2.offset).to.be.equal(sen1.length + 1);
+        expect(res1.length).to.be.equal(sen1.length);
+        expect(res2.length).to.be.equal(sen2.length);
+    });
+
 });


### PR DESCRIPTION
Partially fixes: https://github.com/jonathanpeppers/inclusive-code-comments/issues/47
Replaces: https://github.com/jonathanpeppers/inclusive-code-comments/pull/71

Adds support for ignoring certain words or phrases with a negative
sentiment.  These ignorable words will be replaced with an empty string
of equal length in the comment before sending it to the Text Analytics
service.

Only a couple of phrases have been added to this list, and it can be
expanded in the future as needed.