### PR TITLE
Add some more Slang works which have negative intent.

### DIFF
--- a/src-packed/suggestions.js
+++ b/src-packed/suggestions.js
@@ -64,6 +64,7 @@ const allReplacements = {
     "grandfather": ["flagship", "established", "rollover", "carryover", "classic"],
     "legacy": ["flagship", "established", "rollover", "carryover", "classic"],
     // custom negative sentiment just leave replacements empty
+    // https://www.oxfordinternationalenglish.com/dictionary-of-british-slang/
     "is pants": [],
     "naff": [],
     "tosh": [],

--- a/src-packed/suggestions.js
+++ b/src-packed/suggestions.js
@@ -65,6 +65,14 @@ const allReplacements = {
     "legacy": ["flagship", "established", "rollover", "carryover", "classic"],
     // custom negative sentiment just leave replacements empty
     "is pants": [],
+    "naff": [],
+    "tosh": [],
+    "eejit": [],
+    "faff": [],
+    "gobby": [],
+    "numpty": [],
+    "shirty": [],
+    "wonky": [],
 };
 
 // returns suggestions for certain words

--- a/src-packed/textAnalytics.js
+++ b/src-packed/textAnalytics.js
@@ -115,4 +115,5 @@ const ignorablePhraseRegex =
     "ignore|" +
     "test failure|" +
     "warning|" +
+    "negative|" +
     "";


### PR DESCRIPTION
Fixes #46

This is an update to #59 which adds some more negative intent words.
It also adds the work negative to the ignore list, since that word
will probably be used for PR's to describe mathematical code.