### PR TITLE
Add "wild" to the list of alternate words to "crazy"

### DIFF
--- a/src-packed/suggestions.js
+++ b/src-packed/suggestions.js
@@ -50,7 +50,7 @@ const allReplacements = {
     // ableist
     "normal": ["typical"],
     "abnormal": ["atypical"],
-    "crazy": ["unexpected", "unpredictable"],
+    "crazy": ["unexpected", "unpredictable", "wild"],
     "OCD": ["organized", "detail-oriented"],
     "sanity check": ["quick check", "confidence check", "coherence check"],
     "dummy": ["placeholder", "sample"],


### PR DESCRIPTION
-  "wild" portrays the magnitude of disbelief that is usually associated with "crazy". This also seems to have backing based on suggestions [here](https://www.huffpost.com/entry/disability-language-work_l_5f85d522c5b681f7da1c3839).