### PR TITLE
Change backticks and single quotes to double quotes

### DIFF
--- a/src-packed/textAnalytics.js
+++ b/src-packed/textAnalytics.js
@@ -80,18 +80,17 @@ function removeCodeBlocks (text) {
     return result;
 }
 
-// Replace backticks and single quotes for double quotes
-// since backticks and single quotes make sentiment more negative
-function replaceQuotes (text) {
+// Replace backticks for double quotes, since backticks make sentiment more negative
+// See textAnalytics.js 'Yield Example' test
+function replaceBackticks (text) {
     var result = text.replace(/`/g, "\"");
-    result = result.replace(/\'/g, "\"");
     return result;
 }
 
 export function preprocessText (text) {
     var result = removeCodeBlocks (text);
     result = removeImageTags (result);
-    result = replaceQuotes (result);
+    result = replaceBackticks (result);
     return result;
 }
 

--- a/src-packed/textAnalytics.js
+++ b/src-packed/textAnalytics.js
@@ -80,9 +80,18 @@ function removeCodeBlocks (text) {
     return result;
 }
 
+// Replace backticks and single quotes for double quotes
+// since backticks and single quotes make sentiment more negative
+function replaceQuotes (text) {
+    var result = text.replace(/`/g, "\"");
+    result = result.replace(/\'/g, "\"");
+    return result;
+}
+
 export function preprocessText (text) {
     var result = removeCodeBlocks (text);
     result = removeImageTags (result);
+    result = replaceQuotes (result);
     return result;
 }
 

--- a/test/textAnalytics.js
+++ b/test/textAnalytics.js
@@ -139,4 +139,9 @@ describe('textAnalytics', () => {
         const result = await client.analyzeSentiment("`Change the backticks`");
         expect(result.sentences[0].text).to.be.equal("\"Change the backticks\"");
     });
+
+    it('Yield Example', async () => {
+        const result = await client.analyzeSentiment("`yield` returning / breaking has benefits when there's a chance that you don't iterate through all items.");
+        expect(result.sentences[0].confidenceScores.negative).to.be.lessThan(0.75);
+    });
 });

--- a/test/textAnalytics.js
+++ b/test/textAnalytics.js
@@ -129,4 +129,14 @@ describe('textAnalytics', () => {
         expect(result.sentences[1].sentiment).to.be.equal("neutral");
         expect(result.sentences[2].sentiment).to.be.equal("negative");
     });
+
+    it('Replace Single Quotes', async () => {
+        const result = await client.analyzeSentiment("\'Change the single quotes\'");
+        expect(result.sentences[0].text).to.be.equal("\"Change the single quotes\"");
+    });
+
+    it('Replace Backticks', async () => {
+        const result = await client.analyzeSentiment("`Change the backticks`");
+        expect(result.sentences[0].text).to.be.equal("\"Change the backticks\"");
+    });
 });

--- a/test/textAnalytics.js
+++ b/test/textAnalytics.js
@@ -130,11 +130,6 @@ describe('textAnalytics', () => {
         expect(result.sentences[2].sentiment).to.be.equal("negative");
     });
 
-    it('Replace Single Quotes', async () => {
-        const result = await client.analyzeSentiment("\'Change the single quotes\'");
-        expect(result.sentences[0].text).to.be.equal("\"Change the single quotes\"");
-    });
-
     it('Replace Backticks', async () => {
         const result = await client.analyzeSentiment("`Change the backticks`");
         expect(result.sentences[0].text).to.be.equal("\"Change the backticks\"");


### PR DESCRIPTION
It appears that backticks (`) and single quotes (') add negative sentiment to the text analyzer.
I can't really think of any good reason that this should be the case and it seems that the analyzer does not penalyze the use of double quotes (") - at least not a noticable amount to make the sentence go over the threshold.

Therefore, I thought replacing the backticks and single quotes to double quotes would be a good solution.
Another option is that we could even just remove the backticks and single quotes for the analyzer!

We should keep in mind that single quotes are used in contractions.

Addresses this issue: https://github.com/jonathanpeppers/inclusive-code-comments/issues/92