### PR TITLE
Increase negative sentiment from 75% to 90% confidence

### DIFF
--- a/src-packed/validator.js
+++ b/src-packed/validator.js
@@ -3,6 +3,7 @@
 // NOTE: These values were from the original extension, we can repurpose to display different colors
 const ISSUE_TYPE_YELLOW = "misspelling";
 const ISSUE_TYPE_PURPLE = "style";
+const NEGATIVE_SENTIMENT_THRESHOLD = 0.9;
 const suggestions = require('./suggestions');
 const textAnalytics = require('./textAnalytics');
 var appinsights = null;
@@ -66,7 +67,7 @@ export async function getMatches(text, matches) {
         if (sentence.sentiment !== "negative")
             return;
         console.log(`Index: ${sentence.offset}, Negative sentiment: ${sentence.confidenceScores.negative}`)
-        if (sentence.confidenceScores.negative <= 0.75)
+        if (sentence.confidenceScores.negative <= NEGATIVE_SENTIMENT_THRESHOLD)
             return;
 
         appinsights.trackEvent('negativeSentence', sentence.confidenceScores);


### PR DESCRIPTION
Context: https://github.com/jonathanpeppers/inclusive-code-comments/pull/97#pullrequestreview-900455441

To address a specific case where we saw text like:

    `yield`

negative 87%

Changed to:

    "yield"

negative 62%

Let's increase the threshold to 90% and see if things are less noisy?