### PR TITLE
Add suggestions for "kill", and "stuck"

### DIFF
--- a/src-packed/suggestions.js
+++ b/src-packed/suggestions.js
@@ -57,9 +57,10 @@ const allReplacements = {
     "handicapped": ["disabled", "person with disabilities"],
     // violent
     "hang": ["freeze"],
-    "hanging": ["frozen"],
+    "hanging": ["frozen", "stuck"],
     "crushing it": ["elevating", "exceeding expectations", "excelling"],
     "killing it": ["elevating", "exceeding expectations", "excelling"],
+    "kill": ["stop", "cancel"],
     // ageist
     "grandfather": ["flagship", "established", "rollover", "carryover", "classic"],
     "legacy": ["flagship", "established", "rollover", "carryover", "classic"],


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/inclusive-code-comments/issues/82

Issue #82 appears to be Azure Text Analytics sentiment analysis, but
as a way to address this. We should recommend using "stop" or "cancel"
in favor of "kill".

I tested "killing it", and it appears things are working as intended
when one problematic phrase includes another inside of it. "kill" is a
substring of "killing it", but it appears to work fine.