### PR TITLE
Remove warning when running on Edge Extensions web site

### DIFF
--- a/assets/locales/en/messages.json
+++ b/assets/locales/en/messages.json
@@ -583,10 +583,6 @@
       "description": "Options dialog: text for the textarea with the domains's where the reminder icon is disabled",
       "message": "Disable checking on some websites"
    },
-   "edgeWebstoreSiteNotSupported": {
-      "description": "Error shown when Edge extension is used on https://microsoftedge.microsoft.com, which doesn't work for technical reasons",
-      "message": "Sorry, LanguageTool doesn't work on the website of the Edge Add-on Store. It works anywhere else you write (e.g. Facebook, Gmail, Twitter, LinkedIn)."
-   },
    "el": {
       "description": "language name",
       "message": "Greek"

--- a/src/common/tweaksManager.js
+++ b/src/common/tweaksManager.js
@@ -804,12 +804,6 @@ TweaksManager.NON_COMPATIBLE_TAGS = ["TR", "TH", "TD", "THEAD", "TBODY", "TFOOT"
     unsupportedMessage: () => i18nManager.getMessage("webstoreSiteNotSupported")
 }, {
     match: {
-        hostname: "microsoftedge.microsoft.com"
-    },
-    supported: () => !1,
-    unsupportedMessage: () => i18nManager.getMessage("edgeWebstoreSiteNotSupported")
-}, {
-    match: {
         hostname: "crowdsource.google.com"
     },
     isElementCompatible: e => !(!isTextInput(e) || !e.closest("#question")) || TweaksManager._isElementCompatibleForGoogleServices(e),


### PR DESCRIPTION
Fixes #110

Note that it doesn't seem to actually _work_ on the Edge Extensions site at XYZ. But now it doesn't warn, either.

See in screenshot there is no more warning:
<img width="185" alt="image" src="https://user-images.githubusercontent.com/202643/175666648-ccb057f6-e4f4-40ec-ba1b-90d5624f46bd.png">

But, also, it doesn't light up the extension either:
<img width="224" alt="image" src="https://user-images.githubusercontent.com/202643/175666593-1593bbd1-0a53-4047-9147-9655a512f2f8.png">

So, really this PR just removes what appears to be an innocuous warning.